### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/marzulo/5409e0ac-0171-461c-93d4-75748001fbfd/5d64c867-4cc2-466f-b2a7-15f88e22aec1/_apis/work/boardbadge/724474c9-0094-49c1-86f0-0a0d98e61126)](https://dev.azure.com/marzulo/5409e0ac-0171-461c-93d4-75748001fbfd/_boards/board/t/5d64c867-4cc2-466f-b2a7-15f88e22aec1/Microsoft.RequirementCategory)
 # CodeToCloud with GitHub and Azure DevOps Workshop - Source
 This repository contains the source code for the CodeToCloud workshop. Please follow the instructions in the [CodeToCloud-Student](https://github.com/XpiritBV/CodeToCloud-Student) repository to use this.
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/marzulo/5409e0ac-0171-461c-93d4-75748001fbfd/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.